### PR TITLE
Define noise on all qubits in tests

### DIFF
--- a/qiskit_addon_pna/pna.py
+++ b/qiskit_addon_pna/pna.py
@@ -133,6 +133,18 @@ def generate_noise_mitigating_observable(
     if max_obs_terms < len(observable):
         raise ValueError("max_obs_terms must be larger than the length of observable.")
 
+    if refs_to_noise_model_map:
+        for inst in noisy_circuit.data:
+            if inst.name == "box":
+                anno = get_annotation(inst.operation, InjectNoise)
+                if anno is None:
+                    continue
+                else:
+                    if refs_to_noise_model_map[anno.ref].num_qubits != inst.operation.num_qubits:
+                        raise ValueError(
+                            f"Noise model (ref: {anno.ref}) has a different number of qubits ({refs_to_noise_model_map[anno.ref].num_qubits}) than the associated noisy box ({inst.operation.num_qubits})"
+                        )
+
     observable = SparsePauliOp(observable)
     original_obs_length = len(observable)
 

--- a/test/test_pna.py
+++ b/test/test_pna.py
@@ -37,11 +37,11 @@ class TestPNA(unittest.TestCase):
 
         noise_models = [
             SparsePauliOp(
-                ["XI", "IX", "YI", "IY", "ZI", "IZ", "XX", "YY", "ZZ"],
+                ["IXI", "IIX", "IYI", "IIY", "IZI", "IIZ", "IXX", "IYY", "IZZ"],
                 rng.uniform(1e-5, 1e-2, size=9),
             ),
             SparsePauliOp(
-                ["IX", "XI", "IY", "YI", "IZ", "ZI", "XX", "YY", "ZZ"],
+                ["IXI", "XII", "IYI", "YII", "IZI", "ZII", "XXI", "YYI", "ZZI"],
                 rng.uniform(1e-5, 1e-2, size=9),
             ),
         ]
@@ -63,8 +63,8 @@ class TestPNA(unittest.TestCase):
                 circuit_noisy.cx(edge[0], edge[1])
                 circuit_noisy.append(
                     PauliLindbladError(noise_models[i].paulis, noise_models[i].coeffs.real),
-                    qargs=circuit_noisy.qubits[edge[0] : edge[1] + 1],
-                    cargs=circuit_noisy.clbits[edge[0] : edge[1] + 1],
+                    qargs=circuit_noisy.qubits,
+                    cargs=circuit_noisy.clbits,
                 )
                 circuit_noisy.ry(-np.pi / 2, edge[1])
                 circuit_noisy.barrier()


### PR DESCRIPTION
`generate_boxing_pass_manager` from samplomatic started including all qubits in each box in 0.14, so the boxed circuit test needs to be updated so that the number of qubits in the input noise models matches the associated boxes

This PR raises a value error if the noise model and associated box disagree on the number of qubits they're defined on